### PR TITLE
Use poetry-core build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,5 +20,5 @@ pyyaml = "*"
 [tool.poetry.dev-dependencies]
 
 [build-system]
-requires = ["poetry>=1.1.2"]
-build-backend = "poetry.masonry.api"    
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
The legacy poetry.masonry.api backend was removed in Poetry 2.x, which made sdist installs fail. PyPI release 1.5.3 was built with this change.